### PR TITLE
Make RAA-tools codebase for KMB compatible with BatchUploadTools

### DIFF
--- a/KMB/kmb_massload.py
+++ b/KMB/kmb_massload.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+# -*- coding: utf-8  -*-
 """Get parsed data for whole kmb hitlist and store as json."""
 from __future__ import unicode_literals
 import urllib2
@@ -159,7 +161,7 @@ def process_date(entry):
 
 def process_byline(entry):
     """Handle unknown entries and rearrange names."""
-    if (entry['byline'] == 'Okänd, Okänd') or (entry['byline'] == 'Okänd'):
+    if entry['byline'] in ('Okänd, Okänd', 'Okänd'):
         entry['byline'] = '{{unknown}}'
     elif not entry['byline']:
         entry['byline'] = '{{not provided}}'

--- a/KMB/kmb_massload.py
+++ b/KMB/kmb_massload.py
@@ -110,8 +110,8 @@ def process_depicted(A, url):
 
     Also set bbr, fmis, shm if these are encountered.
 
-    Note that the url need not be shm/fmi/bbr etc. and the might be
-    multiple entries of different or same types.
+    Note that the url need not be for a shm/fmi/bbr etc. entry and there might
+    be multiple entries of different or same types.
     """
     if url.startswith('http://kulturarvsdata.se/raa/fmi/'):
         A['fmis'] = True

--- a/KMB/kmb_massload.py
+++ b/KMB/kmb_massload.py
@@ -1,0 +1,226 @@
+"""Get parsed data for whole kmb hitlist and store as json."""
+from __future__ import unicode_literals
+import urllib2
+import codecs
+import time
+import json
+from xml.dom.minidom import parse
+THROTTLE = 0.5
+
+
+def parser(dom, A):
+    A['problem'] = None
+    # tags to get
+    tagDict = {'namn': ('ns5:itemLabel', None),            # namn
+               'beskrivning': ('pres:description', None),  # med ord
+               'byline': ('pres:byline', None),            # Okänd, Okänd -> {{unknown}}. kasta om sa "efternamn, fornamn" -> "fornamn efternamn".
+               'motiv': ('pres:motive', None),             # också namn? use only if different from itemLabel
+               'copyright': ('pres:copyright', None),      # RAÄ or Utgången upphovsrätt note that ns5:copyright can be different
+               'license': ('ns5:mediaLicense', None),      # good as comparison to the above
+               'source': ('ns5:lowresSource', None),       # source for image (hook up to download) can I check for highres?
+               'dateFrom': ('ns5:fromTime', None),
+               'dateTo': ('ns5:toTime', None),             # datum kan saknas
+               'bildbeteckning': ('pres:idLabel', None),   # bildbeteckning
+               'landskap': ('ns5:provinceName', None),
+               'lan': ('ns5:countyName', None),
+               'land': ('ns5:country', 'rdf:resource', 'http://kulturarvsdata.se/resurser/aukt/geo/country#'),
+               'kommun': ('ns6:municipality', 'rdf:resource', 'http://kulturarvsdata.se/resurser/aukt/geo/municipality#'),
+               'kommunName': ('ns5:municipalityName', None),
+               'socken': ('ns6:parish', 'rdf:resource', 'http://kulturarvsdata.se/resurser/aukt/geo/parish#'),
+               'sockenName': ('ns5:parishName', None),
+               'thumbnail': ('ns5:thumbnailSource', None)}
+    # also has muni, kommun etc. combine some of these (linked to sv.wiki?) into "place"
+    # if cc-by then include byline in copyright/license
+    for tag in tagDict.keys():
+        xmlTag = dom.getElementsByTagName(tagDict[tag][0])
+        if not len(xmlTag) == 0:
+            if tagDict[tag][1] is None:
+                try:
+                    A[tag] = xmlTag[0].childNodes[0].data.strip('"')
+                except IndexError:
+                    # Means data for this field was mising
+                    A[tag] = None
+            else:
+                A[tag] = xmlTag[0].attributes[tagDict[tag][1]].value[len(tagDict[tag][2]):]
+        else:
+            A[tag] = ''
+    # do coordinates separately
+    xmlTag = dom.getElementsByTagName('georss:where')
+    if not len(xmlTag) == 0:
+        xmlTag = xmlTag[0].childNodes[0].childNodes[0]
+        cs = xmlTag.attributes['cs'].value
+        # dec = xmlTag.attributes['decimal'].value
+        coords = xmlTag.childNodes[0].data.split(cs)
+        if len(coords) == 2:
+            A['latitude'] = coords[1][:8]
+            A['longitude'] = coords[0][:8]
+        else:
+            A['problem'] = 'Complain to Lokal_Profil: coord was not a point : %s' % A['ID']
+    # do visualizes separately need not be shm/fmi/bbr etc. can be multiple
+    A['bbr'] = A['fmis'] = False
+    xmlTag = dom.getElementsByTagName('ns5:visualizes')
+    if not len(xmlTag) == 0:
+        A['avbildar'] = []
+        for x in xmlTag:
+            url = x.attributes['rdf:resource'].value
+            process_depicted(A, url)
+    # and an attempt at determining categories
+    xmlTag = dom.getElementsByTagName('ns5:itemClassName')
+    if not len(xmlTag) == 0:
+        A['tagg'] = []
+        for x in xmlTag:
+            try:
+                A['tagg'].append(x.childNodes[0].data.strip())
+            except IndexError:
+                # Means data for this field was mising
+                print "Empty 'ns5:itemClassName' in %s" % A['ID']
+    else:
+        A['tagg'] = []
+    xmlTag = dom.getElementsByTagName('ns5:itemKeyWord')
+    if not len(xmlTag) == 0:
+        if len(A['tagg']) == 0:
+            A['tagg'] = []
+        for x in xmlTag:
+            try:
+                A['tagg'].append(x.childNodes[0].data.strip())
+            except IndexError:
+                # Means data for this field was mising
+                print "Empty 'ns5:itemKeyWord' in %s" % A['ID']
+    # memory seems to be an issue so kill dom
+    del dom, xmlTag
+    # create date field (can one exist and the other not?)
+    if A['dateFrom'] == A['dateTo']:
+        A['date'] = A['dateFrom']
+    elif (A['dateFrom'][:4] == A['dateTo'][:4]) and (A['dateFrom'][5:] == '01-01') and (A['dateTo'][5:] == '12-31'):
+        A['date'] = A['dateFrom'][:4]
+    else:
+        A['date'] = '{{other date|between|' + A['dateFrom'] + '|' + A['dateTo'] + '}}'
+    # rejigg byline
+    if (A['byline'] == 'Okänd, Okänd') or (A['byline'] == 'Okänd'):
+        A['byline'] = '{{unknown}}'
+    elif len(A['byline']) == 0:
+        A['byline'] = '{{not provided}}'
+    else:
+        bySplit = A['byline'].split(',')
+        if len(bySplit) == 2:
+            A['byline'] = (bySplit[1] + ' ' + bySplit[0]).strip()
+        elif len(bySplit) == 1:
+            A['byline'] = bySplit[0]
+        else:
+            pass
+    # ##Creator
+    process_license(A)
+    return A
+
+
+# @todo: consider using the kulturarvsdata tool to resolve bbr type
+def process_depicted(A, url):
+    """
+    Process any FMI or BBR entries in depicted and store back in entry.
+
+    Also set bbr, fmis, shm if these are encountered.
+
+    Note that the url need not be shm/fmi/bbr etc. and the might be
+    multiple entries of different or same types.
+    """
+    if url.startswith('http://kulturarvsdata.se/raa/fmi/'):
+        A['fmis'] = True
+        crop = len('http://kulturarvsdata.se/raa/fmi/')
+        A['avbildar'].append('{{Fornminne|%s}}' % url[crop:])
+    elif url.startswith('http://kulturarvsdata.se/raa/bbr/'):
+        A['bbr'] = True
+        crop = len('http://kulturarvsdata.se/raa/bbr/')
+        num = url[crop:crop+3]
+        typ = ''
+        if num == '214':
+            typ = '|b'
+        elif num == '213':
+            typ = '|a'
+        elif num == '212':
+            typ = '|m'
+        A['avbildar'].append('{{BBR|%s%s}}' % (url[crop:], typ))
+    elif url.startswith('http://kulturarvsdata.se/raa/bbra/'):
+        A['bbr'] = True
+        crop = len('http://kulturarvsdata.se/raa/bbra/')
+        A['avbildar'].append('{{BBR|%s|a}}' % url[crop:])
+    elif url.startswith('http://kulturarvsdata.se/raa/bbrb/'):
+        A['bbr'] = True
+        crop = len('http://kulturarvsdata.se/raa/bbrb/')
+        A['avbildar'].append('{{BBR|%s|b}}' % url[crop:])
+    elif url.startswith('http://kulturarvsdata.se/raa/bbrm/'):
+        A['bbr'] = True
+        crop = len('http://kulturarvsdata.se/raa/bbrm/')
+        A['avbildar'].append('{{BBR|%s|m}}' % url[crop:])
+    else:
+        A['avbildar'].append(url)
+
+
+# @todo: update this per new copyright rules - T164568
+def process_license(entry):
+    """
+    Identify the license and store back in entry.
+
+    Don't include name/byline if unknown.
+    """
+    if entry['license']:
+        trim = 'http://kulturarvsdata.se/resurser/License#'
+        entry['license'] = entry['license'].strip()[len(trim):]
+    # if not copyright = RAÄ and if license='' then, this is probably unfree
+    if (entry['license'] == 'pdmark') or \
+            (entry['copyright'].strip() == 'Utgången upphovsrätt'):
+        entry['license'] = '{{PD-Sweden-photo}}'
+    elif (entry['license'] == 'by') or (entry['copyright'].strip() == 'RAÄ'):
+        # consider changing this to AND since there might be a cc-by image which isn't from RAA.
+        # Alternatively have another if inside which checks whethere copyright = RAA
+        param = '}}'
+        if (entry['byline'] == '{{unknown}}') or \
+                (entry['byline'] == '{{not provided}}'):
+            pass
+        else:
+            param = '|%s}}' % entry['byline']
+        entry['license'] = '{{CC-BY-RAÄ‎%s' % param
+    else:
+        entry['problem'] = (
+            'Det verkar tyvärr som om licensen inte är fri. Copyright="%s", License="%s".<br/>'
+            '<small>Om informationen ovan är inkorrekt så informera gärna Lokal_Profil.</small>' % (entry['copyright'], entry['license']))
+
+
+def kmb_wrapper(idno):
+    """Get partially processed dataobject for a given kmb id."""
+    A = {'ID': idno}
+    fil = urllib2.urlopen('http://kulturarvsdata.se/raa/kmb/' + idno)
+    dom = parse(fil)
+    fil.close()
+    del fil
+    return parser(dom, A)
+
+
+def load_list(filename='kmb_hitlist.json'):
+    """Load json list."""
+    f = codecs.open(filename, 'r', 'utf-8')
+    data = json.load(f)
+    f.close()
+    return data
+
+
+def output_blob(data, filename='kmb_data.json'):
+    """Dump data as jon blob."""
+    f = codecs.open(filename, 'w', 'utf-8')
+    f.write(json.dumps(data, indent=2, ensure_ascii=False))
+    print "%s created" % filename
+
+
+def run(start=None, end=None):
+    """Get parsed data for whole kmb hitlist and store as json."""
+    hitlist = load_list()
+    if start or end:
+        hitlist = hitlist[start:end]
+    data = {}
+    total_count = len(hitlist)
+    for count, kmb in enumerate(hitlist):
+        data[kmb] = kmb_wrapper(kmb)
+        time.sleep(THROTTLE)
+        if count % 100 == 0:
+            timestamp = time.strftime('%H:%M:%S')
+            print '%s - %d of %d parsed' % (timestamp, count, total_count)
+    output_blob(data)

--- a/KMB/kmb_massload.py
+++ b/KMB/kmb_massload.py
@@ -178,7 +178,7 @@ def process_license(entry):
             pass
         else:
             param = '|%s}}' % entry['byline']
-        entry['license'] = '{{CC-BY-RAÄ‎%s' % param
+        entry['license'] = '{{CC-BY-RAÄ%s' % param
     else:
         entry['problem'] = (
             'Det verkar tyvärr som om licensen inte är fri. Copyright="%s", License="%s".<br/>'

--- a/KMB/kmb_massload.py
+++ b/KMB/kmb_massload.py
@@ -5,6 +5,7 @@ import codecs
 import time
 import json
 from xml.dom.minidom import parse
+import batchupload.helpers as helpers
 THROTTLE = 0.5
 
 
@@ -93,26 +94,8 @@ def parser(dom, A):
                 print "Empty 'ns5:itemKeyWord' in %s" % A['ID']
     # memory seems to be an issue so kill dom
     del dom, xmlTag
-    # create date field (can one exist and the other not?)
-    if A['dateFrom'] == A['dateTo']:
-        A['date'] = A['dateFrom']
-    elif (A['dateFrom'][:4] == A['dateTo'][:4]) and (A['dateFrom'][5:] == '01-01') and (A['dateTo'][5:] == '12-31'):
-        A['date'] = A['dateFrom'][:4]
-    else:
-        A['date'] = '{{other date|between|' + A['dateFrom'] + '|' + A['dateTo'] + '}}'
-    # rejigg byline
-    if (A['byline'] == 'Okänd, Okänd') or (A['byline'] == 'Okänd'):
-        A['byline'] = '{{unknown}}'
-    elif len(A['byline']) == 0:
-        A['byline'] = '{{not provided}}'
-    else:
-        bySplit = A['byline'].split(',')
-        if len(bySplit) == 2:
-            A['byline'] = (bySplit[1] + ' ' + bySplit[0]).strip()
-        elif len(bySplit) == 1:
-            A['byline'] = bySplit[0]
-        else:
-            pass
+    process_date(A)
+    process_byline(A)
     # ##Creator
     process_license(A)
     return A
@@ -158,6 +141,30 @@ def process_depicted(A, url):
         A['avbildar'].append('{{BBR|%s|m}}' % url[crop:])
     else:
         A['avbildar'].append(url)
+
+
+def process_date(entry):
+    """Create date field from dateTo and dateFrom."""
+    # (can one exist and the other not?)
+    if entry['dateFrom'] == entry['dateTo']:
+        entry['date'] = entry['dateFrom']
+    elif (entry['dateFrom'][:4] == entry['dateTo'][:4]) and \
+            (entry['dateFrom'][5:] == '01-01') and \
+            (entry['dateTo'][5:] == '12-31'):
+        entry['date'] = entry['dateFrom'][:4]
+    else:
+        entry['date'] = '{{other date|between|%s|%s}}' % (
+            entry['dateFrom'], entry['dateTo'])
+
+
+def process_byline(entry):
+    """Handle unknown entries and rearrange names."""
+    if (entry['byline'] == 'Okänd, Okänd') or (entry['byline'] == 'Okänd'):
+        entry['byline'] = '{{unknown}}'
+    elif not entry['byline']:
+        entry['byline'] = '{{not provided}}'
+    else:
+        entry['byline'] = helpers.flip_name(entry['byline'])
 
 
 # @todo: update this per new copyright rules - T164568

--- a/KMB/kmb_massload.py
+++ b/KMB/kmb_massload.py
@@ -9,6 +9,11 @@ THROTTLE = 0.5
 
 
 def parser(dom, A):
+    """
+    Parse and process the xml metadata into a dict.
+
+    This is all legacy code from RAA-tools
+    """
     A['problem'] = None
     # tags to get
     tagDict = {'namn': ('ns5:itemLabel', None),            # namn
@@ -116,7 +121,7 @@ def parser(dom, A):
 # @todo: consider using the kulturarvsdata tool to resolve bbr type
 def process_depicted(A, url):
     """
-    Process any FMI or BBR entries in depicted and store back in entry.
+    Process any FMIS or BBR entries in depicted and store back in entry.
 
     Also set bbr, fmis, shm if these are encountered.
 

--- a/KMB/make_KMB_info.py
+++ b/KMB/make_KMB_info.py
@@ -224,14 +224,23 @@ class KMBItem(object):
             setattr(self, key, value)
 
     def get_wiki_description(self):
-        """Generate the wikitext description."""
-        wiki_descritpion = ''
-        if self.motiv != self.namn:
-            wiki_descritpion = self.motiv + ' '
-        if self.avbildar:
-            wiki_descritpion += ' '.join(self.avbildar)
+        """
+        Generate the wikitext description.
 
-        return wiki_descritpion.strip()
+        * self.motiv is either the same as the name or a free-text description
+            of what the image depicts.
+        * self.avbildar is a list of wikitext templates (bbr, fmis, shm).
+
+        :return: str
+        """
+        wiki_description = ''
+        if self.motiv != self.namn:
+            wiki_description = self.motiv + ' '
+
+        if self.avbildar:
+            wiki_description += ' '.join(self.avbildar)
+
+        return wiki_description.strip()
 
     # @todo: construct a fallback for descriptions,
     #        and ensure meta cats tie in to this

--- a/KMB/make_KMB_info.py
+++ b/KMB/make_KMB_info.py
@@ -247,7 +247,8 @@ class KMBItem(object):
     def get_description(self):
         """Construct an appropriate description."""
         if self.namn:
-            return self.namn.replace('S:t', 'St')
+            # handle problematic common colon in name
+            return self.namn.replace('S:t', 'Sankt')
         else:
             raise NotImplementedError
 

--- a/KMB/make_KMB_info.py
+++ b/KMB/make_KMB_info.py
@@ -229,7 +229,8 @@ class KMBItem(object):
 
         * self.motiv is either the same as the name or a free-text description
             of what the image depicts.
-        * self.avbildar is a list of wikitext templates (bbr, fmis, shm).
+        * self.avbildar is a list of wikitext templates (bbr, fmis, shm) which
+            all start with a linebreak.
 
         :return: str
         """

--- a/KMB/make_KMB_info.py
+++ b/KMB/make_KMB_info.py
@@ -1,12 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8  -*-
 """
-Information template production
+Construct Kulturmiljöbild-image templates and categories for KMB data.
 
-first mapping file generation could be separated (and if so also knav stuff)
-
-A known assumption is that in avbildad_namn any string containing exactly
-one comma is a person, and any others are assumed to be ships.
+Transforms the partially processed data from kmb_massload into a
+BatchUploadTools compliant json file.
 """
 from __future__ import unicode_literals
 from collections import OrderedDict
@@ -35,8 +33,8 @@ class KMBInfo(MakeBaseInfo):
         Return this as a dict with an entry per file which can be used for
         further processing.
 
-        @param in_file: the path to the metadata file
-        @return: dict
+        :param in_file: the path to the metadata file
+        :return: dict
         """
         return common.open_and_read_file(in_file, as_json=True)
 
@@ -45,6 +43,10 @@ class KMBInfo(MakeBaseInfo):
     def process_data(self, raw_data):
         """
         Take the loaded data and construct a KMBItem for each.
+
+        Populates self.data
+
+        :param raw_data: output from load_data()
         """
         d = {}
         for key, value in raw_data.iteritems():
@@ -63,7 +65,7 @@ class KMBInfo(MakeBaseInfo):
         """
         Update mapping files, load these and package appropriately.
 
-        @param update: whether to first download the latest mappings
+        :param update: whether to first download the latest mappings
         """
         # Currently these are handled as substed templates.
         # redo as either:
@@ -81,8 +83,8 @@ class KMBInfo(MakeBaseInfo):
         The filename has the shape: descr - Collection - id
         and does not include filetype
 
-        @param item: the metadata for the media file in question
-        @return: str
+        :param item: the metadata for the media file in question
+        :return: str
         """
         return helpers.format_filename(item.get_description(), 'KMB', item.ID)
 
@@ -93,8 +95,8 @@ class KMBInfo(MakeBaseInfo):
         """
         Create the description template for a single KMB entry.
 
-        @param item: the metadata for the media file in question
-        @return: str
+        :param item: the metadata for the media file in question
+        :return: str
         """
         template_name = 'Kulturmiljöbild-image'
         template_data = OrderedDict()
@@ -148,7 +150,8 @@ class KMBInfo(MakeBaseInfo):
         """
         Extract any mapped keyword categories or depicted categories.
 
-        @param item: the item to analyse
+        :param item: the KMBItem to analyse
+        :return: list of categories (without "Category:" prefix)
         """
         cats = []
 
@@ -172,9 +175,9 @@ class KMBInfo(MakeBaseInfo):
         """
         Produce maintanance categories related to a media file.
 
-        @param item: the metadata for the media file in question
-        @param content_cats: any content categories for the file
-        @return: list of categories (without "Category:" prefix)
+        :param item: the metadata for the media file in question
+        :param content_cats: any content categories for the file
+        :return: list of categories (without "Category:" prefix)
         """
         pass
         cats = []
@@ -209,7 +212,7 @@ class KMBItem(object):
         """
         Create a KMBItem item from a dict where each key is an attribute.
 
-        @param initial_data: dict of data to set up item with
+        :param initial_data: dict of data to set up item with
         """
         # ensure all required varaibles are present
         required_entries = ('latitude', 'longitude', 'avbildar')
@@ -221,11 +224,7 @@ class KMBItem(object):
             setattr(self, key, value)
 
     def get_wiki_description(self):
-        """
-        Generate the wiki description.
-
-        @todo: change to comma separation
-        """
+        """Generate the wikitext description."""
         wiki_descritpion = ''
         if self.motiv != self.namn:
             wiki_descritpion = self.motiv + ' '
@@ -237,17 +236,15 @@ class KMBItem(object):
     # @todo: construct a fallback for descriptions,
     #        and ensure meta cats tie in to this
     def get_description(self):
-        """Given an item construct an appropriate description."""
+        """Construct an appropriate description."""
         if self.namn:
-            return self.namn
+            return self.namn.replace('S:t', 'St')
         else:
             raise NotImplementedError
 
     # @todo: use kommunkod/sockenkod to go via wikidata - T164576
     def get_depicted_place(self):
-        """
-        given an item get a linked version of the depicted Place
-        """
+        """Get a linked version of the depicted place."""
         s_triggers = ('a', 'o', 'u', 'å', 'e', 'i', 'y', 'ä', 'ö', 's', 'x')
         depicted_place = None
         if not self.land or self.land == 'se':

--- a/KMB/make_KMB_info.py
+++ b/KMB/make_KMB_info.py
@@ -160,7 +160,7 @@ class KMBInfo(MakeBaseInfo):
             cats.append('Archaeological monuments in %s' % item.landskap)
             cats.append('Archaeological monuments in %s County' % item.lan)
         if item.bbr:
-            cats.append('Protected buildings in Sweden')
+            cats.append('Listed buildings in Sweden')
 
         # must be better to do this via safesubst
         for tagg in item.tagg:

--- a/KMB/make_KMB_info.py
+++ b/KMB/make_KMB_info.py
@@ -1,0 +1,273 @@
+#!/usr/bin/python
+# -*- coding: utf-8  -*-
+"""
+Information template production
+
+first mapping file generation could be separated (and if so also knav stuff)
+
+A known assumption is that in avbildad_namn any string containing exactly
+one comma is a person, and any others are assumed to be ships.
+"""
+from __future__ import unicode_literals
+from collections import OrderedDict
+
+import pywikibot
+import batchupload.helpers as helpers
+import batchupload.common as common
+from batchupload.make_info import MakeBaseInfo
+
+
+BATCH_CAT = 'Media contributed by RAÄ'  # stem for maintenance categories
+BATCH_DATE = '2017-05'  # branch for this particular batch upload
+
+
+class KMBInfo(MakeBaseInfo):
+    """Construct file descriptions and filenames for the KMB batch upload."""
+
+    def __init__(self, **options):
+        """Initialise a make_info object."""
+        super(KMBInfo, self).__init__(BATCH_CAT, BATCH_DATE, **options)
+
+    def load_data(self, in_file):
+        """
+        Load the provided data (output from kmb_massload).
+
+        Return this as a dict with an entry per file which can be used for
+        further processing.
+
+        @param in_file: the path to the metadata file
+        @return: dict
+        """
+        return common.open_and_read_file(in_file, as_json=True)
+
+    # @todo: Not all problems should necessarily result in skipping the image
+    #        completely. And some other issues possibly should - T164578
+    def process_data(self, raw_data):
+        """
+        Take the loaded data and construct a KMBItem for each.
+        """
+        d = {}
+        for key, value in raw_data.iteritems():
+            item = KMBItem(value)
+            if item.problem:
+                pywikibot.output(
+                    'The {0} image was skipped because of: {1}'.format(
+                        item.ID, item.problem))
+            else:
+                d[key] = item
+
+        self.data = d
+
+    # @todo: break out substed lists as mappings - T164567
+    def load_mappings(self, update=True):
+        """
+        Update mapping files, load these and package appropriately.
+
+        @param update: whether to first download the latest mappings
+        """
+        # Currently these are handled as substed templates.
+        # redo as either:
+        # * offline mappings: If so consider re-jiging make_info to not assume
+        #   it is alway an online table.
+        # * online tables: If so consider re-jiging make_info to not assume
+        #   these need alway be dumped a offline files first.
+        pass
+
+    # @note: this differs from the one created in RAA-tools
+    def generate_filename(self, item):
+        """
+        Given an item (dict) generate an appropriate filename.
+
+        The filename has the shape: descr - Collection - id
+        and does not include filetype
+
+        @param item: the metadata for the media file in question
+        @return: str
+        """
+        return helpers.format_filename(item.get_description(), 'KMB', item.ID)
+
+    # @todo:
+    # * Add a collaboration + COH template in the source field - T164569
+    # * Add the source link to the source field - T164569
+    def make_info_template(self, item):
+        """
+        Create the description template for a single KMB entry.
+
+        @param item: the metadata for the media file in question
+        @return: str
+        """
+        template_name = 'Kulturmiljöbild-image'
+        template_data = OrderedDict()
+        template_data['short title'] = item.namn
+        template_data['original description'] = item.beskrivning
+        template_data['wiki description'] = item.get_wiki_description()
+        template_data['photographer'] = self.get_photographer(item)
+        template_data['depicted place'] = item.get_depicted_place()
+        template_data['date'] = item.date
+        template_data['permission'] = item.license
+        template_data['ID'] = item.ID
+        template_data['bildbeteckning'] = item.bildbeteckning
+        template_data['notes'] = ''
+        txt = helpers.output_block_template(template_name, template_data, 0)
+
+        # append object location if appropriate
+        if item.latitude and item.longitude:
+            txt += '\n{{Object location dec|%s|%s}}' % (
+                item.latitude, item.longitude)
+
+        return txt
+
+    def get_original_filename(self, item):
+        """
+        Return the url from which the image is fetched.
+
+        :param item: the KMBItem
+        :return: str
+        """
+        return item.source
+
+    # @todo: load mapping list instead of substing template - T164567
+    def get_photographer(self, item):
+        """
+        Return a correctly formated photographer value
+
+        :param item: the KMBItem
+        :return: str
+        """
+        template = 'User:Lokal_Profil/nycklar/creators'
+        return '{{safesubst:%s|%s|t}}' % (template, item.byline)
+
+    # @todo:
+    # * use fmis + bbr for (cached) commonscat searches on wikidata. And if
+    #   found then skip various other. - T164572
+    # * move some of this to KMBItem and set cats at the same time as the
+    #   text is processed.
+    # * Implement taggs from mapping - T164567
+    # * Add parish/municipality categorisation when needed - T164576
+    def generate_content_cats(self, item):
+        """
+        Extract any mapped keyword categories or depicted categories.
+
+        @param item: the item to analyse
+        """
+        cats = []
+
+        # depicted
+        if item.fmis:
+            cats.append('Archaeological monuments in %s' % item.landskap)
+            cats.append('Archaeological monuments in %s County' % item.lan)
+        if item.bbr:
+            cats.append('Protected buildings in Sweden')
+
+        # must be better to do this via safesubst
+        for tagg in item.tagg:
+            # @todo: '{{safesubst:User:Lokal_Profil/nycklar/cats|%s|%s|%s}}' % (tagg, item.land.upper(), item.landskap)
+            pass
+
+        cats = list(set(cats))  # remove any duplicates
+        return cats
+
+    # @todo: Implement creator from mapping - T164567
+    def generate_meta_cats(self, item, content_cats):
+        """
+        Produce maintanance categories related to a media file.
+
+        @param item: the metadata for the media file in question
+        @param content_cats: any content categories for the file
+        @return: list of categories (without "Category:" prefix)
+        """
+        pass
+        cats = []
+
+        # base cats
+        # "Images from the Swedish National Heritage Board" already added by
+        # Kulturmiljöbild-image template
+        cats.append(self.batch_cat)
+
+        # problem cats
+        if not content_cats:
+            cats.append(self.make_maintanance_cat('improve categories'))
+        # if not item.get_description():
+        #     cats.append(self.make_maintanance_cat('add description'))
+
+        # creator cats are classified as meta
+        # @todo: '{{safesubst:User:Lokal_Profil/nycklar/creators|%s|c}} % item.byline
+
+        cats = list(set(cats))  # remove any duplicates
+        return cats
+
+    @classmethod
+    def main(cls, *args):
+        """Command line entry-point."""
+        super(KMBInfo, cls).main(*args)
+
+
+class KMBItem(object):
+    """Store metadata and methods for a single media file."""
+
+    def __init__(self, initial_data):
+        """
+        Create a KMBItem item from a dict where each key is an attribute.
+
+        @param initial_data: dict of data to set up item with
+        """
+        # ensure all required varaibles are present
+        required_entries = ('latitude', 'longitude', 'avbildar')
+        for entry in required_entries:
+            if entry not in initial_data:
+                initial_data[entry] = None
+
+        for key, value in initial_data.iteritems():
+            setattr(self, key, value)
+
+    def get_wiki_description(self):
+        """
+        Generate the wiki description.
+
+        @todo: change to comma separation
+        """
+        wiki_descritpion = ''
+        if self.motiv != self.namn:
+            wiki_descritpion = self.motiv + ' '
+        if self.avbildar:
+            wiki_descritpion += ' '.join(self.avbildar)
+
+        return wiki_descritpion.strip()
+
+    # @todo: construct a fallback for descriptions,
+    #        and ensure meta cats tie in to this
+    def get_description(self):
+        """Given an item construct an appropriate description."""
+        if self.namn:
+            return self.namn
+        else:
+            raise NotImplementedError
+
+    # @todo: use kommunkod/sockenkod to go via wikidata - T164576
+    def get_depicted_place(self):
+        """
+        given an item get a linked version of the depicted Place
+        """
+        s_triggers = ('a', 'o', 'u', 'å', 'e', 'i', 'y', 'ä', 'ö', 's', 'x')
+        depicted_place = None
+        if not self.land or self.land == 'se':
+            kommun_link = self.kommunName
+            # add s if kommun does not end in s or a vowel
+            if not any(self.kommunName.endswith(x) for x in s_triggers):
+                kommun_link += 's'
+            kommun_link += ' kommun'
+            depicted_place = '{{Country|1=SE}}, %s, [[:sv:%s|%s]]' % (
+                self.lan, kommun_link, self.kommunName)
+
+            if self.socken:
+                template = 'User:Lokal_Profil/nycklar/socknar'
+                depicted_place += ', [[:sv:{{safesubst:%s|%s}}|%s (%s)]]' % (
+                    template, self.socken, self.sockenName, self.landskap)
+        else:
+            depicted_place = '{{Country|1=%s}}' % self.land.upper()
+
+        return depicted_place
+
+
+if __name__ == "__main__":
+    KMBInfo.main()

--- a/KMB/make_KMB_info.py
+++ b/KMB/make_KMB_info.py
@@ -173,7 +173,7 @@ class KMBInfo(MakeBaseInfo):
     # @todo: Implement creator from mapping - T164567
     def generate_meta_cats(self, item, content_cats):
         """
-        Produce maintanance categories related to a media file.
+        Produce maintenance categories related to a media file.
 
         :param item: the metadata for the media file in question
         :param content_cats: any content categories for the file
@@ -189,9 +189,9 @@ class KMBInfo(MakeBaseInfo):
 
         # problem cats
         if not content_cats:
-            cats.append(self.make_maintanance_cat('improve categories'))
+            cats.append(self.make_maintenance_cat('improve categories'))
         # if not item.get_description():
-        #     cats.append(self.make_maintanance_cat('add description'))
+        #     cats.append(self.make_maintenance_cat('add description'))
 
         # creator cats are classified as meta
         # @todo: '{{safesubst:User:Lokal_Profil/nycklar/creators|%s|c}} % item.byline

--- a/KMB/requirements.txt
+++ b/KMB/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/lokal-profil/BatchUploadTools.git@0.1.2

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ To run it you will have to install `BatchUploadTools` using:
 *Note*: You might have to add the `--process-dependency-links` flag to the above
 command if you are running a different version of pywikibot from the required one.
 
-These projects are mainly here for my own use and to illustrate how BatchUploadTools
-can be used. There is no guarantee that any of them will work at any given time
-since I'm not keeping them in sync with any later changes to BatchUploadTools.
+These projects are mainly here for my own use and to illustrate how
+BatchUploadTools can be used. There is no guarantee that any of them will work
+with versions of BatchUploadTools later than that given in the
+`requirements.txt` in each directory.
 
 As such they may also include implicit assumptions about the indata, hard-coded
 mappings or insufficient documentation. There may also be nonsensical comments
@@ -28,5 +29,5 @@ precautions.
 * **`KMB`**: A batch upload of images from the National Heritage Board's
   *Kulturmiljöbild*. A list of image ids to upload was provided by the
   organisation and the metadata for these was pre-fetched using `kmb_massload.py`.
-  The code is based hevily on pre-existing code in
+  The code is based heavily on pre-existing code in
   [lokal-profil/RAA-tools](https://github.com/lokal-profil/RAA-tools).

--- a/README.md
+++ b/README.md
@@ -25,3 +25,8 @@ precautions.
 * **`SMM-images`**: A batch upload of images from the National Maritime Museums 
   of Sweden. Metadata was delivered as a .csv file and connected to objects in
   KulturNav.
+* **`KMB`**: A batch upload of images from the National Heritage Board's
+  *Kulturmiljöbild*. A list of image ids to upload was provided by the
+  organisation and the metadata for these was pre-fetched using `kmb_massload.py`.
+  The code is based hevily on pre-existing code in
+  [lokal-profil/RAA-tools](https://github.com/lokal-profil/RAA-tools).


### PR DESCRIPTION
A first stab at making the old codebase compatible. The majority
of `kmb_massload` (which fetches and processes the metadata) comes
verbatim from [lokal-profil/RAA-tools](https://github.com/lokal-profil/RAA-tools)
and is in a terrible shape. But as the code works (produces the
expected output) cleanup and re-factoring is left to later smaller
patches. Similarly a lot of functionality will likely migrate from
`kmb_massload` to `KMBItem`.

Task: [T164566](http://phabricator.wikimedia.org/T164566)
Task:[ T164577](http://phabricator.wikimedia.org/T164577)