### PR TITLE
Handle deleted

### DIFF
--- a/KMB/kmb_massload.py
+++ b/KMB/kmb_massload.py
@@ -17,7 +17,6 @@ def parser(dom, A):
 
     This is all legacy code from RAA-tools
     """
-    A['problem'] = []
     # tags to get
     tagDict = {'namn': ('ns5:itemLabel', None),            # namn
                'beskrivning': ('pres:description', None),  # med ord
@@ -225,8 +224,14 @@ def process_license(entry):
 
 def kmb_wrapper(idno):
     """Get partially processed dataobject for a given kmb id."""
-    A = {'ID': idno}
-    fil = urllib2.urlopen('http://kulturarvsdata.se/raa/kmb/' + idno)
+    A = {'ID': idno, 'problem': []}
+    try:
+        fil = urllib2.urlopen('http://kulturarvsdata.se/raa/kmb/' + idno)
+    except urllib2.HTTPError as e:
+        A['problem'].append(
+            '{0}: http://kulturarvsdata.se/raa/kmb/{1}'.format(e, idno))
+        print A['problem'][0]
+        return A
     dom = parse(fil)
     fil.close()
     del fil
@@ -262,3 +267,7 @@ def run(start=None, end=None):
             timestamp = time.strftime('%H:%M:%S')
             print '%s - %d of %d parsed' % (timestamp, count, total_count)
     output_blob(data)
+
+
+if __name__ == "__main__":
+    run()

--- a/KMB/kmb_massload.py
+++ b/KMB/kmb_massload.py
@@ -227,15 +227,15 @@ def kmb_wrapper(idno):
     A = {'ID': idno, 'problem': []}
     url = 'http://kulturarvsdata.se/raa/kmb/{0}'.format(idno)
     try:
-        fil = urllib2.urlopen(url)
+        f = urllib2.urlopen(url)
     except urllib2.HTTPError as e:
         A['problem'].append('{0}: {1}'.format(e, url))
         print A['problem'][0]
     else:
-        dom = parse(fil)
+        dom = parse(f)
         A = parser(dom, A)
-        fil.close()
-        del fil
+        f.close()
+        del f
 
     return A
 

--- a/KMB/kmb_massload.py
+++ b/KMB/kmb_massload.py
@@ -234,7 +234,6 @@ def kmb_wrapper(idno):
     else:
         dom = parse(fil)
         A = parser(dom, A)
-    finally:
         fil.close()
         del fil
 

--- a/KMB/kmb_massload.py
+++ b/KMB/kmb_massload.py
@@ -225,17 +225,20 @@ def process_license(entry):
 def kmb_wrapper(idno):
     """Get partially processed dataobject for a given kmb id."""
     A = {'ID': idno, 'problem': []}
+    url = 'http://kulturarvsdata.se/raa/kmb/{0}'.format(idno)
     try:
-        fil = urllib2.urlopen('http://kulturarvsdata.se/raa/kmb/' + idno)
+        fil = urllib2.urlopen(url)
     except urllib2.HTTPError as e:
-        A['problem'].append(
-            '{0}: http://kulturarvsdata.se/raa/kmb/{1}'.format(e, idno))
+        A['problem'].append('{0}: {1}'.format(e, url))
         print A['problem'][0]
-        return A
-    dom = parse(fil)
-    fil.close()
-    del fil
-    return parser(dom, A)
+    else:
+        dom = parse(fil)
+        A = parser(dom, A)
+    finally:
+        fil.close()
+        del fil
+
+    return A
 
 
 def load_list(filename='kmb_hitlist.json'):


### PR DESCRIPTION
Make `kmb_massload` not crash on 404 errors and ensure it's output remains compatible with `make_kmb_info`.

[T165277](https://phabricator.wikimedia.org/T165277)