### PR TITLE
Only use primary classes for categorisation, when mapped

### DIFF
--- a/KMB/kmb_massload.py
+++ b/KMB/kmb_massload.py
@@ -118,28 +118,10 @@ def parser(dom, A):
             url = x.attributes['rdf:resource'].value
             process_depicted(A, url)
 
-    # and an attempt at determining categories
-    xmlTag = dom.getElementsByTagName('ns5:itemClassName')
-    if not len(xmlTag) == 0:
-        A['tag'] = []
-        for x in xmlTag:
-            try:
-                A['tag'].append(x.childNodes[0].data.strip())
-            except IndexError:
-                # Means data for this field was mising
-                print "Empty 'ns5:itemClassName' in %s" % A['ID']
-    else:
-        A['tag'] = []
-    xmlTag = dom.getElementsByTagName('ns5:itemKeyWord')
-    if not len(xmlTag) == 0:
-        if len(A['tag']) == 0:
-            A['tag'] = []
-        for x in xmlTag:
-            try:
-                A['tag'].append(x.childNodes[0].data.strip())
-            except IndexError:
-                # Means data for this field was mising
-                print "Empty 'ns5:itemKeyWord' in %s" % A['ID']
+    # attempt at determining tags (used for catgories)
+    process_tags(A, dom, 'item_classes', 'ns5:itemClassName')
+    process_tags(A, dom, 'item_keywords', 'ns5:itemKeyWord')
+
     # memory seems to be an issue so kill dom
     del dom, xmlTag
     process_date(A)
@@ -151,6 +133,25 @@ def parser(dom, A):
     A['bbr'] = list(A['bbr'])
     A['fmis'] = list(A['fmis'])
     return A
+
+
+def process_tags(entry, dom, label, xml_tag):
+    """
+    Process tags of a given type.
+
+    :param entry: the dict of parsed data for the image
+    :param dom: the dom being analysed
+    :param label: the label under which the processed tags should be stored
+    :param xml_tag: the xml tag name to search for
+    """
+    entry[label] = []
+    elements = dom.getElementsByTagName(xml_tag)
+    for element in elements:
+        try:
+            entry[label].append(element.childNodes[0].data.strip())
+        except IndexError:
+            # Means data for this field was mising
+            print "Empty '{0}' in {1}".format(xml_tag, entry['ID'])
 
 
 def process_depicted(entry, url):

--- a/KMB/make_KMB_info.py
+++ b/KMB/make_KMB_info.py
@@ -80,6 +80,8 @@ class KMBInfo(MakeBaseInfo):
         kommun_file = os.path.join(MAPPINGS_DIR, 'kommun.json')
         countries_file = os.path.join(MAPPINGS_DIR, 'countries_for_cats.json')
         tags_file = os.path.join(MAPPINGS_DIR, 'tags.json')
+        primary_classes_file = os.path.join(
+            MAPPINGS_DIR, 'primary_classes.json')
         photographer_file = os.path.join(MAPPINGS_DIR, 'photographers.json')
         kmb_files_file = os.path.join(MAPPINGS_DIR, 'kmb_files.json')
         commonscat_file = os.path.join(MAPPINGS_DIR, 'commonscat.json')
@@ -129,6 +131,8 @@ class KMBInfo(MakeBaseInfo):
             countries_file, as_json=True)
         self.mappings['tags'] = common.open_and_read_file(
             tags_file, as_json=True)
+        self.mappings['primary_classes'] = common.open_and_read_file(
+            primary_classes_file, as_json=True)
 
     def get_photographer_mapping(self, photographer_page):
         """
@@ -394,7 +398,8 @@ class KMBInfo(MakeBaseInfo):
 
         # add tag categories unless a commonscat was found
         if not found_commonscat:
-            item.make_tag_categories(self.category_cache)
+            item.make_item_class_categories(self.category_cache)
+            item.make_item_keyword_categories(self.category_cache)
 
         # @todo: Add parish/municipality categorisation when needed
         #        i.e. if not item.needs_place_cat - T164576
@@ -605,13 +610,46 @@ class KMBItem(object):
             self.content_cats.add(
                 'Archaeological monuments in %s County' % self.lan)
 
-    def make_tag_categories(self, cache):
+    def make_item_class_categories(self, cache):
         """
-        Construct categories from the provided tags.
+        Construct categories from the item class values.
+
+        :param cache: cache for category existence
+        """
+        primary_classes = self.kmb_info.mappings['primary_classes']
+
+        # find the class/tag that is also in primary_classes
+        primary_tag = None
+        intersection = list(set(primary_classes) & set(self.item_classes))
+        if len(intersection) == 1:
+            primary_tag = intersection[0]
+        elif len(intersection) > 1:
+            pywikibot.warning(
+                "Found two primary classes. Need to rethink the logic. "
+                "{idno}: '{primary}'".format(
+                    idno=self.ID, primary="', '".join(intersection)))
+
+        if not primary_tag or not self.add_single_tag(primary_tag, cache):
+            for tag in self.item_classes:
+                if tag != primary_tag:
+                    self.add_single_tag(tag, cache)
+
+    def make_item_keyword_categories(self, cache):
+        """
+        Construct categories from the item keyword values.
+
+        :param cache: cache for category existence
+        """
+        for tag in self.item_keywords:
+            self.add_single_tag(tag, cache)
+
+    def add_single_tag(self, tag, cache):
+        """
+        Construct a category from a single provided tag.
 
         The mapping follows four scenarios:
         * A guessed, and validated, category on municipal level in Sweden.
-        * An exact category for Sweden.
+        * An exact category on national level for Sweden.
         * A guessed, and validated, category where 'Sweden' is replaced
           by the country name in the Sweden specific category.
         * A default category (either a "to be categorised by country" category
@@ -620,44 +658,43 @@ class KMBItem(object):
         Populates self.content_cats
 
         :param cache: cache for category existence
+        :param tag: the tag (string) to be mapped to a category
+        :return: bool whether a category was added
         """
+        # avoid similar cat to fallback in make_commonscat_categories
+        if (self.fmis and tag == 'Fornminnen') or \
+                (self.bbr and tag.startswith('Byggnadsminnen')):
+            return False
+
         tag_map = self.kmb_info.mappings['tags']
         country_map = self.kmb_info.mappings['countries']
-        for tag in self.tag:
-            if (self.fmis and tag == 'Fornminnen') or \
-                    (self.bbr and tag.startswith('Byggnadsminnen')):
-                # avoid similar cat to fallback in make_commonscat_categories
-                continue
+        if tag in tag_map:
+            cat = None
+            if (not self.land or self.land == 'se') and tag_map[tag].get('SE'):
+                cat = tag_map[tag].get('SE')
 
-            if tag in tag_map:
-                cat = None
-                if not self.land or self.land == 'se' and \
-                        tag_map[tag].get('SE'):
-                    cat = tag_map[tag].get('SE')
-
-                    # attempt municipal categorisation
-                    if self.kommunName:
-                        test_cat = tag_map[tag].get('SE').replace(
-                            'Sweden', '{} Municipality'.format(
-                                self.kommunName))
-                        if self.kmb_info.category_exists(test_cat, cache):
-                            self.needs_place_cat = False
-                            cat = test_cat
-                elif self.land.upper() in country_map and \
-                        tag_map[tag].get('base'):
-                    # guess a category
-                    test_cat = tag_map[tag].get('base').format(
-                        country_map(self.land.upper()))
+                # attempt municipal categorisation
+                if self.kommunName:
+                    test_cat = tag_map[tag].get('SE').replace(
+                        'Sweden', '{} Municipality'.format(self.kommunName))
                     if self.kmb_info.category_exists(test_cat, cache):
                         self.needs_place_cat = False
                         cat = test_cat
+            elif self.land.upper() in country_map and tag_map[tag].get('base'):
+                test_cat = tag_map[tag].get('base').format(
+                    country_map(self.land.upper()))
+                if self.kmb_info.category_exists(test_cat, cache):
+                    self.needs_place_cat = False
+                    cat = test_cat
 
-                if not cat:
-                    # fallback independent of country
-                    cat = tag_map[tag].get('default')
+            if not cat:
+                # fallback independent of country
+                cat = tag_map[tag].get('default')
 
-                if cat:
-                    self.content_cats.add(cat)
+            if cat:
+                self.content_cats.add(cat)
+                return True
+        return False
 
     def get_photographer(self):
         """

--- a/KMB/mappings/primary_classes.json
+++ b/KMB/mappings/primary_classes.json
@@ -1,0 +1,7 @@
+[
+    "Hällristning", 
+    "Runristning/runsten", 
+    "Boplatser och visten", 
+    "Husgrund, förhistorisk/medeltida", 
+    "Slott"
+]


### PR DESCRIPTION
Provided a list of primary classes check first if any of the
item_class tags are in this list and can be used to generate a
category. If not then use the remaining to generate categories.

This also splits the handling of item_class tags and
item_keyword tags with all of the latter always getting used.

Task: [T160054](https://phabricator.wikimedia.org/T160054)