### PR TITLE
Add a parish or municipal category if needs_place_cat is True

### DIFF
--- a/KMB/kmb_massload.py
+++ b/KMB/kmb_massload.py
@@ -142,15 +142,26 @@ def parser(dom, A):
                 print "Empty 'ns5:itemKeyWord' in %s" % A['ID']
     # memory seems to be an issue so kill dom
     del dom, xmlTag
+
     process_date(A)
     process_byline(A)
-    # ##Creator
     process_license(A)
 
     # convert sets to lists to allow for json storage)
     A['bbr'] = list(A['bbr'])
     A['fmis'] = list(A['fmis'])
+    normalise_ids(A)
     return A
+
+
+def normalise_ids(entry):
+    """Normalise municipality, parish and country codes."""
+    if entry['kommun']:
+        entry['kommun'] = '{:04d}'.format(int(entry['kommun']))  # zero pad
+    if entry['socken']:
+        entry['socken'] = '{:04d}'.format(int(entry['socken']))  # zero pad
+    if entry['land']:
+        entry['land'] = entry['land'].upper()
 
 
 def process_depicted(entry, url):

--- a/KMB/kmb_massload.py
+++ b/KMB/kmb_massload.py
@@ -151,6 +151,7 @@ def parser(dom, A):
     A['bbr'] = list(A['bbr'])
     A['fmis'] = list(A['fmis'])
     normalise_ids(A)
+    handle_gotland(A)
     return A
 
 
@@ -162,6 +163,19 @@ def normalise_ids(entry):
         entry['socken'] = '{:04d}'.format(int(entry['socken']))  # zero pad
     if entry['land']:
         entry['land'] = entry['land'].upper()
+
+
+def handle_gotland(entry):
+    """
+    Ensure Gotland has municipality code and not just county/province.
+
+    Relies on the fact that county/province and municipality are equivalent
+    in this one case. Which is probably also why this particular municipality
+    id is frequently left out.
+    """
+    if not entry['kommun'] and 'Gotland' in (entry['lan'], entry['landskap']):
+        entry['kommun'] = '0980'  # Gotlands kommun
+        entry['kommunName'] = 'Gotland'
 
 
 def process_depicted(entry, url):

--- a/KMB/make_KMB_info.py
+++ b/KMB/make_KMB_info.py
@@ -772,11 +772,8 @@ class KMBItem(object):
         socken_map = self.kmb_info.mappings['socken']
         depicted_place = None
         if not self.land or self.land == 'SE':
-            if 'Gotland' in (self.lan, self.landskap) and not self.kommun:
-                # since lan/landskap/kommun are equivalent in this case
-                self.kommun = '0980'  # Gotlands kommun
-
             depicted_place = '{{Country|1=SE}}'
+
             if self.kommun:
                 self.wd['kommun'] = kommun_map[self.kommun]['wd']
                 depicted_place += ', {{city|%s}}' % self.wd['kommun']

--- a/KMB/make_KMB_info.py
+++ b/KMB/make_KMB_info.py
@@ -415,8 +415,7 @@ class KMBInfo(MakeBaseInfo):
         if not found_commonscat:
             item.make_tag_categories(self.category_cache)
 
-        # @todo: Add parish/municipality categorisation when needed
-        #        i.e. if not item.needs_place_cat - T164576
+        # Add parish/municipality categorisation when needed
         if item.needs_place_cat:
             item.make_place_category()
 
@@ -652,7 +651,7 @@ class KMBItem(object):
 
             if tag in tag_map:
                 cat = None
-                if not self.land or self.land == 'se' and \
+                if not self.land or self.land == 'SE' and \
                         tag_map[tag].get('SE'):
                     cat = tag_map[tag].get('SE')
 
@@ -664,11 +663,10 @@ class KMBItem(object):
                         if self.kmb_info.category_exists(test_cat, cache):
                             self.needs_place_cat = False
                             cat = test_cat
-                elif self.land.upper() in country_map and \
-                        tag_map[tag].get('base'):
+                elif self.land in country_map and tag_map[tag].get('base'):
                     # guess a category
                     test_cat = tag_map[tag].get('base').format(
-                        country_map(self.land.upper()))
+                        country_map(self.land))
                     if self.kmb_info.category_exists(test_cat, cache):
                         self.needs_place_cat = False
                         cat = test_cat
@@ -716,21 +714,18 @@ class KMBItem(object):
         return '[{url} {link_text}]\n{template}'.format(
             url=self.source, link_text=txt, template=template)
 
-    #@todo: move zero-padding to kmb_massload
     def make_place_category(self):
         """Add category for parish or municipality."""
         kommun_map = self.kmb_info.mappings['kommun']
         socken_map = self.kmb_info.mappings['socken']
         cat = None
 
-        if not self.land or self.land == 'se':
+        if not self.land or self.land == 'SE':
             if self.socken:
-                socken_id = '{:04d}'.format(int(self.socken))  # zero pad
-                cat = socken_map[socken_id]['commonscat']
+                cat = socken_map[self.socken]['commonscat']
 
             if not cat and self.kommun:
-                kommun_id = '{:04d}'.format(int(self.kommun))  # zero pad
-                cat = kommun_map[kommun_id]['commonscat']
+                cat = kommun_map[self.kommun]['commonscat']
 
         if cat:
             self.content_cats.add(cat)
@@ -750,20 +745,18 @@ class KMBItem(object):
         kommun_map = self.kmb_info.mappings['kommun']
         socken_map = self.kmb_info.mappings['socken']
         depicted_place = None
-        if not self.land or self.land == 'se':
+        if not self.land or self.land == 'SE':
             if 'Gotland' in (self.lan, self.landskap) and not self.kommun:
                 # since lan/landskap/kommun are equivalent in this case
                 self.kommun = '0980'  # Gotlands kommun
 
             depicted_place = '{{Country|1=SE}}'
             if self.kommun:
-                kommun_id = '{:04d}'.format(int(self.kommun))  # zero pad
-                self.wd['kommun'] = kommun_map[kommun_id]['wd']
+                self.wd['kommun'] = kommun_map[self.kommun]['wd']
                 depicted_place += ', {{city|%s}}' % self.wd['kommun']
 
                 if self.socken:
-                    socken_id = '{:04d}'.format(int(self.socken))  # zero pad
-                    self.wd['socken'] = socken_map[socken_id]['wd']
+                    self.wd['socken'] = socken_map[self.socken]['wd']
                     depicted_place += ', {{city|%s}}' % self.wd['socken']
             else:
                 if self.lan:
@@ -774,7 +767,7 @@ class KMBItem(object):
                     self.meta_cats.add(
                         'needing categorisation (no municipality)')
         else:
-            depicted_place = '{{Country|1=%s}}' % self.land.upper()
+            depicted_place = '{{Country|1=%s}}' % self.land
             self.meta_cats.add('needing categorisation (not from Sweden)')
 
         return depicted_place

--- a/KMB/make_KMB_info.py
+++ b/KMB/make_KMB_info.py
@@ -86,16 +86,19 @@ class KMBInfo(MakeBaseInfo):
         photographer_page = 'Institution:Riksantikvarieämbetet/KMB/creators'
 
         if update_mappings:
+            query_props = {'commonscat': 'commonscat'}
             self.mappings['socken'] = KMBInfo.query_to_lookup(
                 'SELECT ?item ?value ?commonscat WHERE {'
                 '?item wdt:P777 ?value'
                 ' . OPTIONAL { ?item wdt:P373 ?commonscat }'
-                '}')
+                '}',
+                props=query_props)
             self.mappings['kommun'] = KMBInfo.query_to_lookup(
                 'SELECT ?item ?value ?commonscat WHERE {'
                 '?item wdt:P525 ?value'
                 ' . OPTIONAL { ?item wdt:P373 ?commonscat }'
-                '}')
+                '}',
+                props=query_props)
             self.mappings['photographers'] = self.get_photographer_mapping(
                 photographer_page)
             self.mappings['kmb_files'] = self.get_existing_kmb_files()
@@ -198,6 +201,10 @@ class KMBInfo(MakeBaseInfo):
             else:
                 lookup[key] = {'wd': qid}
                 for prop, label in props.iteritems():
+                    if entry[prop] and not entry[prop].type:
+                        # pywikibot sparql has issues with unicode
+                        # this can be dumped when we switch to PY3
+                        entry[prop] = repr(entry[prop]).decode('utf-8')
                     lookup[key][label] = entry[prop]
         return lookup
 


### PR DESCRIPTION
Now also request commonscat for all municipalitites and civil parishes.

Tries to add a parish category first, then municipality if the first fails. Adds a meta category if neither works.

Municipal and parish and country codes are now all standardised during harvest.

Task: [T164576](https://phabricator.wikimedia.org/T164576)