### PR TITLE
Link Creator

### DIFF
--- a/KMB/kmb_massload.py
+++ b/KMB/kmb_massload.py
@@ -109,7 +109,7 @@ def parser(dom, A, log):
             A['latitude'] = coords[1][:8]
             A['longitude'] = coords[0][:8]
         else:
-            A['problem'].append("Coord was not a point: '{0}'".format(cs))
+            A['problem'].append('Coord was not a point: "{0}"'.format(cs))
 
     # do ns5:visualizes separately
     A['bbr'] = set()
@@ -157,7 +157,7 @@ def process_tags(entry, dom, label, xml_tag, log):
             entry[label].append(element.childNodes[0].data.strip())
         except IndexError:
             # Means data for this field was mising
-            log.write("{0} -- Empty '{1}'".format(entry['ID'], xml_tag))
+            log.write('{0} -- Empty "{1}"'.format(entry['ID'], xml_tag))
 
 
 def normalise_ids(entry):
@@ -205,8 +205,8 @@ def process_depicted(entry, url):
         if url.startswith(pattern):
             if idno != url[len(pattern):].strip():
                 raise ValueError(
-                    "Depicted started with '{0}' but idno has wrong "
-                    "format: {1}".format(pattern, url))
+                    'Depicted started with "{0}" but idno has wrong '
+                    'format: {1}'.format(pattern, url))
             entry[template.template_type].add(idno)
             avbildar = template.output()
             break
@@ -290,7 +290,7 @@ def process_license(entry):
     else:
         entry['problem'].append(
             "It looks like the license isn't free. "
-            "Copyright='{0}', License='{1}'.".format(
+            'Copyright="{0}", License="{1}".'.format(
                 entry['copyright'], entry['license']))
     entry['license_text'] = license_text
 
@@ -345,5 +345,5 @@ def run(start=None, end=None):
     pywikibot.output(log.close_and_confirm())
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     run()

--- a/KMB/make_KMB_info.py
+++ b/KMB/make_KMB_info.py
@@ -332,7 +332,7 @@ class KMBInfo(MakeBaseInfo):
             namespace = '|'.join(namespace)
 
         g = pywikibot.data.api.ListGenerator(
-            "exturlusage", euquery=url, site=self.commons,
+            'exturlusage', euquery=url, site=self.commons,
             eunamespace=namespace, euprotocol=protocol, euprop='title|url')
         return g
 
@@ -717,9 +717,9 @@ class KMBItem(object):
             primary_tag = intersection[0]
         elif len(intersection) > 1:
             pywikibot.warning(
-                "Found two primary classes. Need to rethink the logic. "
-                "{idno}: '{primary}'".format(
-                    idno=self.ID, primary="', '".join(intersection)))
+                'Found two primary classes. Need to rethink the logic. '
+                '{idno}: "{primary}"'.format(
+                    idno=self.ID, primary='", "'.join(intersection)))
 
         if not primary_tag or not self.add_single_tag(primary_tag, cache):
             for tag in self.item_classes:
@@ -800,7 +800,7 @@ class KMBItem(object):
                 (self.byline in photographer_map):
             creator = photographer_map[self.byline].get('creator')
             if creator:
-                photographer = 'Creator:{0}'.format(creator)
+                photographer = '{{Creator:%s}}' % creator
 
         return photographer or self.byline  # fallback on plain byline
 
@@ -819,7 +819,7 @@ class KMBItem(object):
         template = '{{Riksantikvarieämbetet cooperation project|coh}}'
         txt = ''
         if self.byline:
-            txt += '%s / ' % self.byline
+            txt += '{} / '.format(self.byline)
         txt += 'Kulturmiljöbild, Riksantikvarieämbetet'
         return '[{url} {link_text}]\n{template}'.format(
             url=self.source, link_text=txt, template=template)
@@ -867,9 +867,9 @@ class KMBItem(object):
                     depicted_place += ', {{city|%s}}' % self.wd['socken']
             else:
                 if self.lan:
-                    depicted_place += ', %s' % self.lan
+                    depicted_place += ', {}'.format(self.lan)
                 elif self.landskap:
-                    depicted_place += ', %s' % self.landskap
+                    depicted_place += ', {}'.format(self.landskap)
                 else:
                     self.meta_cats.add(
                         'needing categorisation (no municipality)')
@@ -880,5 +880,5 @@ class KMBItem(object):
         return depicted_place
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     KMBInfo.main()


### PR DESCRIPTION
Also:
* Standardise string format usage. Percentage formatting only when
  used in strings which naturally contain curly braces e.g.
  (sparql, template calls).
* Standardise string quotes. Double quotes only for docstrings or
  strings which naturally contain a single quote/apostrophe.