### PR TITLE
Allow multiple primary tags

### DIFF
--- a/KMB/make_KMB_info.py
+++ b/KMB/make_KMB_info.py
@@ -734,7 +734,7 @@ class KMBItem(object):
         * item_classes: (human construct, building, castle) returns [castle]
         * item_classes: (human construct, building, church) returns []
         * item_classes: (building, castle, animal, chicken) returns
-            [runestone, chicken]
+            [castle, chicken]
 
         :return: the matching class
         """

--- a/KMB/make_KMB_info.py
+++ b/KMB/make_KMB_info.py
@@ -730,25 +730,17 @@ class KMBItem(object):
         """
         Discover which, if any, of the item classes is the primary one.
 
-        If primary_classes contains (castle, runestone, chicken)
-        then:
-        * item_classes: (human construct, building, castle) returns castle
-        * item_classes: (human construct, building, church) returns None
-        * item_classes: (building, runestone, chicken) raises a warning and
-          returns None
+        If primary_classes contains (castle, runestone, chicken) then:
+        * item_classes: (human construct, building, castle) returns [castle]
+        * item_classes: (human construct, building, church) returns []
+        * item_classes: (building, castle, animal, chicken) returns
+            [runestone, chicken]
 
         :return: the matching class
         """
         primary_classes = self.kmb_info.mappings['primary_classes']
         intersection = list(set(primary_classes) & set(self.item_classes))
-        if len(intersection) == 1:
-            return intersection[0]
-        elif len(intersection) > 1:
-            pywikibot.warning(
-                'Found {num} primary classes. Need to rethink the logic. '
-                '{idno}: "{primary}"'.format(
-                    num=len(intersection), idno=self.ID,
-                    primary="', '".join(intersection)))
+        return intersection
 
     def make_item_class_categories(self, cache):
         """
@@ -756,13 +748,15 @@ class KMBItem(object):
 
         :param cache: cache for category existence
         """
-        # find the class/tag that is also in primary_classes
-        primary_tag = self.isolate_primary_class()
+        # find the class/tag(s) that are also in primary_classes
+        primary_tags = self.isolate_primary_class()
 
-        if not primary_tag or not self.add_single_tag(primary_tag, cache):
+        if not primary_tags or \
+                not all(self.add_single_tag(primary_tag, cache)
+                        for primary_tag in primary_tags):
+            # unless all primary tags were found, add all classes
             for tag in self.item_classes:
-                if tag != primary_tag:
-                    self.add_single_tag(tag, cache)
+                self.add_single_tag(tag, cache)
 
     def make_item_keyword_categories(self, cache):
         """

--- a/KMB/mappings/primary_classes.json
+++ b/KMB/mappings/primary_classes.json
@@ -381,7 +381,6 @@
     "Fyndplats", 
     "Gränsmärke", 
     "Samlingsplats", 
-    "Övrigt", 
     "Avrättningsplats", 
     "Byggnad annan", 
     "Stenindustri", 


### PR DESCRIPTION
Multiple primary tags proved to not be unusual since two separate
class trees were often used. Allow for this but require them all to
be mapped in order to skip the others.

Also:
* Removed one inappropriate primary_tag which is always unmapped.

Task: [T167352](https://phabricator.wikimedia.org/T167352)